### PR TITLE
增加查询价格功能

### DIFF
--- a/app/controller/UserAzureServer.php
+++ b/app/controller/UserAzureServer.php
@@ -1026,4 +1026,39 @@ class UserAzureServer extends UserBase
 
         return json($set);
     }
+    public function price() {
+        $location = input('location/s');
+        $vm_size = input('vm_size/s');
+        $vm_sku = str_replace('Standard_', '', $vm_size);
+    
+    $apiUrl = "https://prices.azure.com/api/retail/prices?api-version=2021-10-01-preview";
+    $query = "armRegionName eq '$location' and SkuName eq '$vm_sku' and priceType eq 'Consumption' and serviceName eq 'Virtual Machines' ";
+
+    $params = ['$filter' => $query];
+    $url = $apiUrl . '&' . http_build_query($params);
+
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HEADER, false);
+
+    $response = curl_exec($ch);
+
+    if ($response === false) {
+        // 请求失败处理
+        return null;
+    }
+
+    curl_close($ch);
+
+    $json_data = json_decode($response, true);
+
+    $prices = array();
+
+    foreach ($json_data['Items'] as $item) {
+        $prices[] = $item['retailPrice'];
+    }
+
+    return json_encode(['prices' => $prices]);
+    }
 }

--- a/app/view/user/azure/server/create.html
+++ b/app/view/user/azure/server/create.html
@@ -27,6 +27,7 @@
                 </li>
                 <li>创建 <code>D,F</code> 系列虚拟机时，默认启用 <code>Accelerated Networking</code></li>
                 <li>密码必须包含小写字母、大写字母、数字和特殊符号这四个组成部分中的三个，长度大于 12 且小于 72</li>
+                <li>查询价格功能用于获取当前选择地区和规格的虚拟机价格</li>
               </ul>
             </div>
           </div>
@@ -280,6 +281,57 @@
       ipv6_inst.open();
     }
   });
+//查询价格
+$('#query_price').on('click', function () {
+      mdui.snackbar({
+        message: '查询价格中...',
+        position: 'top',
+        timeout: '500',
+      });
+
+      $.ajax({
+        method: 'POST',
+        url: "/user/server/azure/price",
+        data: {
+            vm_size: $('#vm_size').val(),
+            location: $('#vm_location').val(),
+        },
+        dataType: "json",
+        success: function (priceData) {
+          if (priceData === null) {
+            mdui.snackbar({
+              message: '查询不到价格：网络连接错误',
+              position: 'top'
+            });
+          } else {
+          var decodedData = JSON.parse(priceData.replace(/\\\"/g, '"'));
+          var prices = decodedData.prices;
+            if (prices.length === 0) {
+              mdui.snackbar({
+                message: '查询不到价格：该地域似乎无此型号',
+                position: 'top'
+              });
+            } else {
+                //Linux价格一般比Windows低
+              var linuxPrice, windowsPrice;
+              if (prices[0] < prices[1]) {
+                linuxPrice = prices[0].toFixed(4);
+                windowsPrice = prices[1].toFixed(4);
+              } else {
+                linuxPrice = prices[1].toFixed(4);
+                windowsPrice = prices[0].toFixed(4);
+              }
+            
+              mdui.snackbar({
+                message: '查询到每小时价格：Linux: $' + linuxPrice + ', Windows: $' + windowsPrice,
+                position: 'top',
+                timeout: '3000'
+              });
+            }
+          }
+        },
+      });
+    });
 
   $('#create').on('click', function () {
     mdui.confirm('创建过程中请不要离开本页面', '创建确认',

--- a/app/view/user/azure/server/create.html
+++ b/app/view/user/azure/server/create.html
@@ -186,11 +186,17 @@
 
       <div class="mdui-card mdui-m-t-2">
         <div class="mdui-card-actions">
-          <div class="mdui-row-xs-2">
+          <div class="mdui-row-xs-3">
             <div class="mdui-col">
               <button id="load_available_models"
                 class="mdui-btn mdui-btn-raised mdui-btn-dense mdui-btn-block mdui-color-indigo">
                 加载可用型号
+              </button>
+            </div>
+            <div class="mdui-col">
+              <button id="query_price"
+                class="mdui-btn mdui-btn-raised mdui-btn-dense mdui-btn-block mdui-color-indigo">
+                查询价格
               </button>
             </div>
             <div class="mdui-col">

--- a/route/app.php
+++ b/route/app.php
@@ -74,6 +74,7 @@ Route::get('/user/server/azure/rule/log',         'UserAzureServerRule/log');
 Route::resource('/user/server/azure',             'UserAzureServer');
 Route::post('/user/server/azure/search',          'UserAzureServer/search');
 Route::post('/user/server/azure/available',       'UserAzureServer/available');
+Route::post('/user/server/azure/price',           'UserAzureServer/price');
 Route::patch('/user/server/azure/:action/:uuid',  'UserAzureServer/status');
 Route::put('/user/server/azure/resize/:uuid',     'UserAzureServer/resize');
 Route::put('/user/server/azure/redisk/:uuid',     'UserAzureServer/redisk');


### PR DESCRIPTION
在虚拟机创建页面增加查询价格按钮，如图
![image](https://github.com/azpanel/azpanel/assets/81958172/acc4aa74-880a-4086-97ce-4689b02d041c)
![image](https://github.com/azpanel/azpanel/assets/81958172/abaf22e8-2027-43ea-b50d-bebddc819340)
将使用PHP cURL 库请求Azure api获取当前选择地区和规格的虚拟机价格，价格以小时计
请先启用PHP cURL 库
参考文档：https://learn.microsoft.com/zh-cn/rest/api/cost-management/retail-prices/azure-retail-prices